### PR TITLE
Allow overriding duplicates in DLL dependencies at dotnet-sdk-setup-h…

### DIFF
--- a/pkgs/development/compilers/dotnet/dotnet-sdk-setup-hook.sh
+++ b/pkgs/development/compilers/dotnet/dotnet-sdk-setup-hook.sh
@@ -23,7 +23,7 @@ _linkPackages() {
         for x in "$src"/*/*; do
             dir=$dest/$(basename "$(dirname "$x")")
             mkdir -p "$dir"
-            ln -s "$x" "$dir"/
+            ln -sf "$x" "$dir"/
         done
     )
 }


### PR DESCRIPTION
When a user sets runtime a identifier, as for example:
```
<RuntimeIdentifiers>linux-x64;win-x64</RuntimeIdentifiers>
```

nuget-to-json command creates a lock file containing entries with runtime packages. This is great, but `buildDotnetModule` then fails during the nuget cache construction, since `dotnet-sdk.packages` is unconditionally propagated to the nugetCache.

A simple solution to that problem is to override a simlink to what any of the entries as far as we get the same DLL multiple times.